### PR TITLE
Only allow deployments from a specific room

### DIFF
--- a/scripts/deploy.coffee
+++ b/scripts/deploy.coffee
@@ -22,12 +22,14 @@ _ = require("underscore")
 deploymanager_token = process.env.DEPLOYMANAGER_TOKEN
 deploymanager_url  = "https://deployer.pipelinedeals.com/api"
 
+DEPLOYMENT_ROOMS = ["Deployments", "Operations talk"];
+
 module.exports = (robot) ->
 
   robot.respond /deploy( (.*))?/i, (msg) ->
 
-    # Only deploy from the correct hipchat room
-    if msg.message.room != "Deployments"
+    # Only deploy from the whitelisted rooms in Hipchat
+    unless msg.message.room in DEPLOYMENT_ROOMS      
       return
 
     command = msg.match[2]

--- a/scripts/deploy.coffee
+++ b/scripts/deploy.coffee
@@ -23,8 +23,15 @@ deploymanager_token = process.env.DEPLOYMANAGER_TOKEN
 deploymanager_url  = "https://deployer.pipelinedeals.com/api"
 
 module.exports = (robot) ->
+
   robot.respond /deploy( (.*))?/i, (msg) ->
+
+    # Only deploy from the correct hipchat room
+    if msg.message.room != "Deployments"
+      return
+
     command = msg.match[2]
+
     if command is "status"
       statusRequest(msg)
     else


### PR DESCRIPTION
This PR introduces a new check into our custom `deploy.coffee` hubot responder. If the name of the room which sent the message isn't `Deployments`, nothing happens.